### PR TITLE
Synchronously unwrapping

### DIFF
--- a/src/NServiceBus.Kafka/Connection/ConsumerHolder.cs
+++ b/src/NServiceBus.Kafka/Connection/ConsumerHolder.cs
@@ -256,18 +256,14 @@ namespace NServiceBus.Transports.Kafka.Connection
 
                 await throttler.WaitAsync(tokenSource.Token);
 
-                var message = await retrieved.UnWrap().ConfigureAwait(false);
-
+                var message = retrieved.UnWrap();
 
                 OffsetsReceived.AddOrUpdate(retrieved.TopicPartitionOffset, false, (a, b) => false);                  
 
                 await Process(message).ConfigureAwait(false);
 
                 OffsetsReceived.AddOrUpdate(retrieved.TopicPartitionOffset, true, (a, b) => true);                   
-                
-
             }
-
             catch (Exception ex)
             {
                 Logger.Error("Kafka transport failed pushing a message through pipeline", ex);

--- a/src/NServiceBus.Kafka/MessageWrapper/MessageExtensionMethods.cs
+++ b/src/NServiceBus.Kafka/MessageWrapper/MessageExtensionMethods.cs
@@ -1,18 +1,13 @@
 ﻿using NServiceBus.Transport.Kafka;
 using RdKafka;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NServiceBus.Transports.Kafka.Wrapper
 {
     internal static class MessageExtensionMethods
     {
-        
-        internal static async Task<MessageWrapper> UnWrap(this Message kafkaMessage)
+        internal static MessageWrapper UnWrap(this Message kafkaMessage)
         {
             MessageWrapper m;
             using (var stream = new MemoryStream(kafkaMessage.Payload))
@@ -22,7 +17,7 @@ namespace NServiceBus.Transports.Kafka.Wrapper
 
             if (m == null)
             {
-                throw new ArgumentNullException("Message is null");
+                throw new ArgumentNullException(nameof(kafkaMessage));
             }
 
             if (m.ReplyToAddress != null)


### PR DESCRIPTION
The serializer and deserializer API is synchronous. No need to use async. Saves state machine generation